### PR TITLE
rails_12factorを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,10 @@ group :test do
   gem 'webdrivers'
 end
 
+group :production do
+  gem 'rails_12factor'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -222,6 +227,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4)
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails_12factor
   sass-rails (~> 5)
   selenium-webdriver
   spring


### PR DESCRIPTION
**What**
rails_12factorを導入

**Why**
静的アセットファイルやログの保存先をHeroku用に微調整するため